### PR TITLE
add gnu template for cheyenne

### DIFF
--- a/src/mkmf/templates/cheyenne-gnu.mk
+++ b/src/mkmf/templates/cheyenne-gnu.mk
@@ -1,69 +1,75 @@
-# template for Intel compilers
-# typical use with mkmf:
-# mkmf -t cheyenne-intel.mk -c "-Duse_libMPI -Duse_netCDF" path_names /usr/local/include
-
+# template for the GNU fortran compiler
+# typical use with mkmf
+# mkmf -t linux-gnu.mk -c"-Duse_libMPI -Duse_netCDF" path_names /usr/local/include
 ############
 # commands #
 ############
+FC = mpif90
+CC = gcc
+CXX = g++
+LD = mpif90 $(MAIN_PROGRAM)
 
-FC = ifort
-CC = icc
-CXX = icpc
-LD = ifort
-
-############
-#  flags   #
-############
-
+#########
+# flags #
+#########
 DEBUG =
 REPRO =
 VERBOSE =
 OPENMP =
 
-MAKEFLAGS += --jobs=8
+MAKEFLAGS += --jobs=$(shell grep '^processor' /proc/cpuinfo | wc -l)
 
-FPPFLAGS := -fpp -Wp,-w
+FPPFLAGS :=
 
-FFLAGS := -fno-alias -auto -safe-cray-ptr -ftz -assume byterecl -i4 -r8 -nowarn -sox -traceback
-FFLAGS_OPT = -O3 -debug minimal -fp-model source -override-limits
-FFLAGS_DEBUG = -g -O0 -check -check noarg_temp_created -check nopointer -warn -warn noerrors -fpe0 -ftrapuv
-FFLAGS_REPRO = -O2 -debug minimal -fp-model source -override-limits
-FFLAGS_OPENMP = -openmp
-FFLAGS_VERBOSE = -v -V -what
+FFLAGS := -fcray-pointer -fdefault-double-8 -fdefault-real-8 -Waliasing -ffree-line-length-none -fno-range-check
+FFLAGS += -I$(shell nc-config --includedir)
+FFLAGS += $(shell pkg-config --cflags-only-I mpich2-c)
+FFLAGS_OPT = -O3
+FFLAGS_REPRO = -O2 -fbounds-check
+FFLAGS_DEBUG = -O0 -g -W -fbounds-check -fbacktrace -ffpe-trap=invalid,zero,overflow
+FFLAGS_OPENMP = -fopenmp
+FFLAGS_VERBOSE =
 
-CFLAGS := -D__IFC -sox -traceback
-CFLAGS_OPT = -O2 -debug minimal
-CFLAGS_OPENMP = -openmp
-CFLAGS_DEBUG = -O0 -g -ftrapuv
+CFLAGS := -D__IFC
+CFLAGS += -I$(shell nc-config --includedir)
+CFLAGS += $(shell pkg-config --cflags-only-I mpich2-c)
+CFLAGS_OPT = -O2
+CFLAGS_OPENMP = -fopenmp
+CFLAGS_DEBUG = -O0 -g
+
+# Optional Testing compile flags.  Mutually exclusive from DEBUG, REPRO, and OPT
+# *_TEST will match the production if no new option(s) is(are) to be tested.
+FFLAGS_TEST = -O2
+CFLAGS_TEST = -O2
 
 LDFLAGS :=
-LDFLAGS_OPENMP := -openmp
-LDFLAGS_VERBOSE := -Wl,-V,--verbose,-cref,-M
-
-# start with blank LIBS
-LIBS :=
+LDFLAGS_OPENMP := -fopenmp
+LDFLAGS_VERBOSE :=
 
 ifneq ($(REPRO),)
-  CFLAGS += $(CFLAGS_REPRO)
-  FFLAGS += $(FFLAGS_REPRO)
+CFLAGS += $(CFLAGS_REPRO)
+FFLAGS += $(FFLAGS_REPRO)
 else ifneq ($(DEBUG),)
-  CFLAGS += $(CFLAGS_DEBUG)
-  FFLAGS += $(FFLAGS_DEBUG)
+CFLAGS += $(CFLAGS_DEBUG)
+FFLAGS += $(FFLAGS_DEBUG)
+else ifneq ($(TEST),)
+CFLAGS += $(CFLAGS_TEST)
+FFLAGS += $(FFLAGS_TEST)
 else
-  CFLAGS += $(CFLAGS_OPT)
-  FFLAGS += $(FFLAGS_OPT)
+CFLAGS += $(CFLAGS_OPT)
+FFLAGS += $(FFLAGS_OPT)
 endif
 
 ifneq ($(OPENMP),)
-  CFLAGS += $(CFLAGS_OPENMP)
-  FFLAGS += $(FFLAGS_OPENMP)
-  LDFLAGS += $(LDFLAGS_OPENMP)
+CFLAGS += $(CFLAGS_OPENMP)
+FFLAGS += $(FFLAGS_OPENMP)
+LDFLAGS += $(LDFLAGS_OPENMP)
 endif
 
 ifneq ($(VERBOSE),)
-  CFLAGS += $(CFLAGS_VERBOSE)
-  FFLAGS += $(FFLAGS_VERBOSE)
-  LDFLAGS += $(LDFLAGS_VERBOSE)
+CFLAGS += $(CFLAGS_VERBOSE)
+FFLAGS += $(FFLAGS_VERBOSE)
+LDFLAGS += $(LDFLAGS_VERBOSE)
 endif
 
 ifeq ($(NETCDF),3)
@@ -73,15 +79,7 @@ ifeq ($(NETCDF),3)
   endif
 endif
 
-ifneq ($(findstring netcdf/4,$(LOADEDMODULES)),)
-  LIBS += -lnetcdff -lnetcdf -lhdf5_hl -lhdf5 -lz
-else
-  LIBS += -lnetcdf
-endif
-
-#LIBS += -lmpi
-LIBS += -lmpi -lsma
-#LIBS += -lmkl_blas95_lp64 -lmkl_lapack95_lp64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential
+LIBS := $(shell nc-config --flibs) $(shell pkg-config --libs mpich2-f90)
 LDFLAGS += $(LIBS)
 
 #---------------------------------------------------------------------------


### PR DESCRIPTION
Adds GNU compiler template for cheyenne to mkmf.

To compile FMS with GNU on cheyenne:
```
module load gnu/6.4.0
cd MOM6-cases
mkdir -p build/gnu/shared/repro/
cd build/gnu/shared/repro/
rm -f path_names
../../../../src/mkmf/bin/list_paths ../../../../src/FMS
../../../../src/mkmf/bin/mkmf -t ../../../../src/mkmf/templates/cheyenne-gnu.mk -p libfms.a -c "-Duse_libMPI -Duse_netCDF -DSPMD" path_names
make NETCDF=3 REPRO=1 libfms.a -j
```
To compile MOM6 with GNU on cheyenne:
```
cd ../../../../    # i.e., cd back to MOM6-cases 
mkdir -p build/gnu/ocean_only/repro/
cd build/gnu/ocean_only/repro/
rm -f path_names
../../../../src/mkmf/bin/list_paths ./ ../../../../src/MOM6/{config_src/dynamic,config_src/solo_driver,src/{*,*/*}}/
../../../../src/mkmf/bin/mkmf -t ../../../../src/mkmf/templates/cheyenne-gnu.mk -o '-I../../shared/repro' -p MOM6 -l '-L../../shared/repro -lfms' -c '-Duse_libMPI -Duse_netCDF -DSPMD' path_names
make NETCDF=3 REPRO=1 MOM6 -j
```

Before running MOM6 with GNU compiler, make sure your environment is set correctly:
```
module load gnu/6.4.0
```